### PR TITLE
Make UL PKCS11 respect default log level

### DIFF
--- a/lib/ul/pkcs11/pkcs11.c
+++ b/lib/ul/pkcs11/pkcs11.c
@@ -13,7 +13,7 @@
 
 #include <external/pkcs11/pkcs11.h>
 
-LOG_MODULE_REGISTER(ul_pkcs11, LOG_LEVEL_INF);
+LOG_MODULE_REGISTER(ul_pkcs11);
 
 #include "pkcs11_args_helper.h"
 #include "pkcs11_internal.h"

--- a/tests/lib/ul/pksc11/unit/testcase.yaml
+++ b/tests/lib/ul/pksc11/unit/testcase.yaml
@@ -2,6 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+common:
+  type: unit
 tests:
-  pkcs11.basic:
-    type: unit
+  pkcs11.basic.info_logging:
+    extra_configs:
+      - CONFIG_LOG_DEFAULT_LEVEL=3
+  pkcs11.basic.no_logging:
+    extra_configs:
+      - CONFIG_LOG_DEFAULT_LEVEL=0


### PR DESCRIPTION
Right now, setting the default level of an application does not respect the default log level itself. As this is recommended for libs, we change it, and add tests for it. 