### PR TITLE
ci: pin actions to full-length sha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.2
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
           fetch-depth: 2
           show-progress: true
@@ -33,7 +33,7 @@ jobs:
           echo "/usr/lib/llvm-20/bin" >> $GITHUB_PATH
 
       - name: Restore Zephyr workspace cache
-        uses: actions/cache@v4.2.4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: |
             modules
@@ -73,7 +73,7 @@ jobs:
             -T ./zephyr-security-showcase/
 
       - name: Upload Twister Reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: twister-reports
           path: |
@@ -92,17 +92,17 @@ jobs:
     if: (!cancelled())
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
         with:
           path: artifacts
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@3a74b2957438d0b6e2e61d67b05318aa25c9e6c6 #v2.20.0
         with:
           files: "artifacts/**/twister_report.xml"
 
       - name: Create code coverage report
-        uses: irongut/CodeCoverageSummary@v1.3.0
+        uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 #v1.3.0
         with:
           filename: artifacts/**/coverage.xml
           format: markdown
@@ -110,7 +110,7 @@ jobs:
           output: both
 
       - name: Add coverage report to PR
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         if: github.event_name == 'pull_request'
         with:
           recreate: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,21 +18,21 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
       - name: Generate final image tag
         id: final_docker_tag
         run: echo "value=${{ github.event.inputs.ZEPHYR_DOCKER_TAG }}-$(date -u +'%Y%m%d-%H%M%S')" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and (maybe) push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
         with:
           context: .
           push: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
As tags are not immutable in GitHub, it is best practice to pin GitHub action versions to full-length shas.

This implements and closes #27.