### PR TITLE
chore: add commit lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,14 @@ on:
   workflow_dispatch:
 
 jobs:
+  commit-lint:
+    name: "Enforce Conventional Commits"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+      - name: Lint Git commit message
+        uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed #v6.2.1
   build-and-test:
     name: "Build and test showcase"
     runs-on: ubuntu-latest

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,1 @@
+export default {extends: ['@commitlint/config-conventional']};


### PR DESCRIPTION
This adds linting commit messages to ensure a consistent format.

This closes #28