### PR TITLE
chore: add sbom generation on merge into main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,12 @@ jobs:
         run: |
           west twister --integration -T zephyr-security-showcase/samples
 
+      - name: Initialize SBOM generator
+        if: &sbom_condition
+          ${{github.event_name == 'push' && github.ref == 'refs/heads/main'}}
+        run: |
+          west spdx --init -d build/pkcs11
+
       - name: Build and analyze sample application for NRF7002DK
         run: |
           # TODO: FIXME Normally, one would use `west twister` to build the sample application,
@@ -93,6 +99,24 @@ jobs:
             twister-out/twister.json
             twister-out/twister.xml
             twister-out/twister_report.xml
+
+      - name: Generate SBOM
+        if: *sbom_condition
+        run: |
+          west spdx -d build/pkcs11 -s spdx --analyze-includes --include-sdk
+
+      - name: Upload SBOM Reports
+        if: *sbom_condition
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
+        with:
+          name: sbom-spdx
+          path: |
+            spdx/app.spdx
+            spdx/build.spx
+            spdx/modules-deps.spdx
+            spdx/sdk.spdx
+            spdx/zephyr.spdx
+
 
   publish-test-results:
     name: "Publish Tests Results"

--- a/README.md
+++ b/README.md
@@ -132,3 +132,24 @@ west build ... -- \
 ```
 
 This enable codechecker, but only for files in this module (NRF SDK and module code does not passfails).
+
+### Generate SBOM
+
+To generate the SBOM run the following commands:
+
+```
+west spdx --init -d <build_dir>/<application_name>
+west build -b <board_name> <path_to_application> -d <build_dir>/
+west spdx -d <build_dir>/<application_name> -s <output_dir>
+```
+
+To generate the SBOM for the pkcs11 sample run and store the result in `spdx`:
+
+```
+west spdx --init -d build/pkcs11
+west build -b nrf7002dk/nrf5340/cpuapp/ns ./zephyr-security-showcase/samples/ul/pkcs11 -d build/
+west spdx -d build/pkcs11 -s spdx
+```
+
+This does not work for `native_sim`, see the [Zephyr
+Documentation](https://docs.zephyrproject.org/latest/develop/west/zephyr-cmds.html#software-bill-of-materials-west-spdx).

--- a/samples/ul/pkcs11/prj.conf
+++ b/samples/ul/pkcs11/prj.conf
@@ -12,3 +12,6 @@ CONFIG_REBOOT=y
 # Enable logging
 CONFIG_CONSOLE=y
 CONFIG_LOG=y
+
+# Enable Metadata output for SBOM generation
+CONFIG_BUILD_OUTPUT_META=y


### PR DESCRIPTION
To provide an up to date SBOM, `west spdx` is employed to create and store an SBOM.

This closes #15.