### PR TITLE
fix: remove MIT mention from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,5 +177,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ```
-SPDX-License-Identifier: Apache-2.0 OR MIT
+SPDX-License-Identifier: Apache-2.0
 ```


### PR DESCRIPTION
In the README's SPDX license string the MIT was license was mentioned erroneously.