### PR TITLE
Use own minimal image in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
     name: "Build and test showcase"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.28.2
+      image: ghcr.io/methodpark/zephyr-security-showcase/ci:v0.28.4-20250905-144300
       options: '--entrypoint /bin/bash'
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.2
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.17.4
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
@@ -62,10 +62,6 @@ jobs:
         run: |
           west init -l ./zephyr-security-showcase
           west update
-
-      - name: Setup SCA
-        run: |
-          pip install codechecker
 
       - name: Build and test sample applications for integration platforms
         run: |


### PR DESCRIPTION
Additionally, as codechecker is already installed, we don't need to do that in the CI again.